### PR TITLE
✨ run C code with isolate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build & Run Server
         run: |
           docker build -t waffle-judge .
-          docker run -d -p 8080:8080 waffle-judge
+          docker run --privileged -dp 8080:8080 waffle-judge
       - name: Install Test Cli
         run: |
           npm install -g @usebruno/cli

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 - 실행 시 `http://127.0.0.1:8080` 에 서버를 띄웁니다.
 - `POST /submit` 경로에 `{ language: String, code: String }` 형태의 JSON 데이터를 받습니다.
-- 받은 데이터를 language (C, JAVA 를 지원합니다.) 에 따라 컴파일하고 실행합니다.
+- 받은 데이터를 language 에 따라 컴파일하고 실행합니다.
 - 실행 결과를 JSON 형태로 반환합니다.
 
 ## 구조
@@ -12,8 +12,10 @@
 - `waffle-judge-server/src/main.rs`가 진입점이며 서버를 띄우는 역할을 합니다.
   - 서버를 띄울 때에는 `actix-web`을 이용하며, 직렬화를 위해 `serde`를 사용합니다.
 - `waffle-judge-core/src/languages/` 에는 각 언어별 실행함수가 들어있습니다.
-- 실행하려면 임시로 파일을 저장해둘 경로가 필요한데, `.temp` 경로가 해당 역할을 합니다.
-  - 매 실행마다 `.temp/${랜덤 문자열}` 경로에 임시 폴더가 생성됩니다. 이때 `uuid` 를 이용합니다.
+- 실행하려면 임시로 파일을 저장해둘 경로가 필요한데, `$HOME/.waffle-judge/temp` 경로가 해당 역할을 합니다.
+  - 매 실행마다 `$HOME/.waffle-judge/temp/${랜덤 문자열}` 경로에 임시 폴더가 생성됩니다. 이때 `uuid` 를 이용합니다.
+  - 실행할 때에는 [`isolate`](https://github.com/ioi/isolate)를 활용하여 코드를 안전하게 수행할 수 있게 합니다.
+    - 컴파일할 때에는 `isolate` 를 이용하지 않습니다.
   - 실행이 끝나면 임시 폴더가 제거됩니다.
 - API 콜 테스트 및 자동화 테스트에는 Bruno 를 활용합니다. Bruno Collection 은 [여기](./tests/bruno) 에 있습니다.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ cargo run
 
 ```sh
 docker build -t waffle-judge .
-docker run -dp 8080:8080 waffle-judge
+docker run --privileged -dp 8080:8080 waffle-judge
 ```
 
 ## Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
 name = "judge-core"
 version = "0.1.0"
 dependencies = [
+ "rand",
  "serde",
  "serde_json",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ COPY --from=isolate-builder /usr/src/isolate/isolate /usr/local/bin/isolate
 COPY --from=isolate-builder /usr/src/isolate/isolate-check-environment /usr/local/bin/isolate-check-environment
 COPY --from=isolate-builder /usr/src/isolate/default.cf /usr/local/etc/isolate
 
-ENTRYPOINT ["/usr/local/bin/waffle-judge"]
+ENTRYPOINT ["/usr/local/bin/judge-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # build waffle-judge
 #
-FROM rust:1.80.0-slim as waffle-judge-builder
+FROM rust:1.80.0-slim AS waffle-judge-builder
 
 WORKDIR /usr/src/waffle-judge
 COPY . .
@@ -10,7 +10,7 @@ RUN cargo build --release
 #
 # build isolate
 #
-FROM debian:12.6-slim as isolate-builder
+FROM debian:12.6-slim AS isolate-builder
 
 # install isolate
 RUN apt-get update && apt-get --no-install-recommends install -y \
@@ -23,7 +23,7 @@ RUN make isolate
 #
 # runner
 #
-FROM debian:12.6-slim as runner
+FROM debian:12.6-slim AS runner
 
 # install language specific tools
 RUN apt-get update && apt-get --no-install-recommends install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,4 @@ COPY --from=isolate-builder /usr/src/isolate/isolate /usr/local/bin/isolate
 COPY --from=isolate-builder /usr/src/isolate/isolate-check-environment /usr/local/bin/isolate-check-environment
 COPY --from=isolate-builder /usr/src/isolate/default.cf /usr/local/etc/isolate
 
-RUN echo '#!/bin/sh' > /usr/local/bin/start.sh \
-  && echo 'isolate --init' >> /usr/local/bin/start.sh \
-  && echo '/usr/local/bin/judge-server' >> /usr/local/bin/start.sh \
-  && chmod +x /usr/local/bin/start.sh
-
-ENTRYPOINT ["/usr/local/bin/start.sh"]
+ENTRYPOINT ["/usr/local/bin/waffle-judge"]

--- a/judge-core/Cargo.toml
+++ b/judge-core/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/judge-core/src/languages/c.rs
+++ b/judge-core/src/languages/c.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use super::ExecutionResult;
 
-pub fn run_c_code(code: &str, temp_dir: &std::path::Path) -> ExecutionResult {
+pub fn run_c_code(code: &str, temp_dir: &std::path::PathBuf) -> ExecutionResult {
     let source_path = temp_dir.join("example.c");
     let binary_path = temp_dir.join("example");
     let box_id = rand::thread_rng().gen_range(0..1000);

--- a/judge-core/src/languages/c.rs
+++ b/judge-core/src/languages/c.rs
@@ -3,15 +3,15 @@ use std::process::Command;
 use super::ExecutionResult;
 
 pub fn run_c_code(code: &str, temp_dir: &std::path::Path) -> ExecutionResult {
-    let temp_c_dir = temp_dir.join("example.c");
-    let temp_exec_dir = temp_dir.join("example");
+    let source_path = temp_dir.join("example.c");
+    let binary_path = temp_dir.join("example");
 
-    std::fs::write(&temp_c_dir, code).expect("Unable to write file");
+    std::fs::write(&source_path, code).expect("Unable to write file");
 
     let compile_output = Command::new("gcc")
-        .arg(&temp_c_dir)
+        .arg(&source_path)
         .arg("-o")
-        .arg(&temp_exec_dir)
+        .arg(&binary_path)
         .output()
         .expect("Failed to compile C code");
 
@@ -27,7 +27,7 @@ pub fn run_c_code(code: &str, temp_dir: &std::path::Path) -> ExecutionResult {
         .arg(format!("--dir={}", temp_dir.display()))
         .arg("--run")
         .arg("--")
-        .arg(&temp_exec_dir)
+        .arg(&binary_path)
         .output()
         .expect("Failed to execute C code");
 

--- a/judge-core/src/languages/c.rs
+++ b/judge-core/src/languages/c.rs
@@ -1,3 +1,5 @@
+use rand::Rng;
+
 use std::process::Command;
 
 use super::ExecutionResult;
@@ -5,6 +7,7 @@ use super::ExecutionResult;
 pub fn run_c_code(code: &str, temp_dir: &std::path::Path) -> ExecutionResult {
     let source_path = temp_dir.join("example.c");
     let binary_path = temp_dir.join("example");
+    let box_id = rand::thread_rng().gen_range(0..1000);
 
     std::fs::write(&source_path, code).expect("Unable to write file");
 
@@ -23,13 +26,25 @@ pub fn run_c_code(code: &str, temp_dir: &std::path::Path) -> ExecutionResult {
         };
     }
 
+    let box_id_arg = format!("--box-id={}", box_id);
+    Command::new("isolate")
+        .arg(&box_id_arg)
+        .arg("--init")
+        .output()
+        .expect("Failed to init box");
     let output = Command::new("isolate")
         .arg(format!("--dir={}", temp_dir.display()))
+        .arg(&box_id_arg)
         .arg("--run")
         .arg("--")
         .arg(&binary_path)
         .output()
         .expect("Failed to execute C code");
+    Command::new("isolate")
+        .arg(&box_id_arg)
+        .arg("--cleanup")
+        .output()
+        .expect("Failed to cleanup box");
 
     if !output.status.success() {
         return ExecutionResult {

--- a/judge-core/src/languages/c.rs
+++ b/judge-core/src/languages/c.rs
@@ -23,7 +23,11 @@ pub fn run_c_code(code: &str, temp_dir: &std::path::Path) -> ExecutionResult {
         };
     }
 
-    let output = Command::new(&temp_exec_dir)
+    let output = Command::new("isolate")
+        .arg(format!("--dir={}", temp_dir.display()))
+        .arg("--run")
+        .arg("--")
+        .arg(&temp_exec_dir)
         .output()
         .expect("Failed to execute C code");
 

--- a/judge-core/src/languages/java.rs
+++ b/judge-core/src/languages/java.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use super::ExecutionResult;
 
-pub fn run_java_code(code: &str, temp_dir: &std::path::Path) -> ExecutionResult {
+pub fn run_java_code(code: &str, temp_dir: &std::path::PathBuf) -> ExecutionResult {
     let source_path = temp_dir.join("Main.java");
 
     std::fs::write(&source_path, code).expect("Unable to write file");

--- a/judge-core/src/languages/java.rs
+++ b/judge-core/src/languages/java.rs
@@ -3,12 +3,12 @@ use std::process::Command;
 use super::ExecutionResult;
 
 pub fn run_java_code(code: &str, temp_dir: &std::path::Path) -> ExecutionResult {
-    let temp_java_file = temp_dir.join("Main.java");
+    let source_path = temp_dir.join("Main.java");
 
-    std::fs::write(&temp_java_file, code).expect("Unable to write file");
+    std::fs::write(&source_path, code).expect("Unable to write file");
 
     let compile_output = Command::new("javac")
-        .arg(&temp_java_file)
+        .arg(&source_path)
         .output()
         .expect("Failed to compile Java code");
 

--- a/judge-server/src/main.rs
+++ b/judge-server/src/main.rs
@@ -18,12 +18,7 @@ async fn ping() -> impl Responder {
 
 #[post("/submit")]
 async fn submit_code(submission: web::Json<CodeSubmission>) -> impl Responder {
-    let home_dir = std::env::var("HOME").expect("cannot find home directory");
-    let random_string: String = Uuid::new_v4().to_string();
-    let temp_dir = format!("{}/.waffle-judge/temp/{}", home_dir, random_string);
-    let temp_dir = std::path::Path::new(&temp_dir);
-
-    std::fs::create_dir_all(&temp_dir).unwrap();
+    let temp_dir = create_judge_folder();
 
     let output = match submission.language {
         Language::C => run_c_code(&submission.code, &temp_dir),
@@ -37,11 +32,19 @@ async fn submit_code(submission: web::Json<CodeSubmission>) -> impl Responder {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let home_dir = std::env::var("HOME").expect("cannot find home directory");
-    let waffle_judge_dir = format!("{}/.waffle-judge/temp", home_dir);
-    std::fs::create_dir_all(&waffle_judge_dir).unwrap();
     HttpServer::new(|| App::new().service(ping).service(submit_code))
         .bind("0.0.0.0:8080")?
         .run()
         .await
+}
+
+fn create_judge_folder() -> std::path::PathBuf {
+    let home_dir = std::env::var("HOME").expect("cannot find home directory");
+    let random_string: String = Uuid::new_v4().to_string();
+    let waffle_judge_dir = format!("{}/.waffle-judge/temp", home_dir);
+    std::fs::create_dir_all(&waffle_judge_dir).unwrap();
+    let temp_dir = format!("{}/.waffle-judge/temp/{}", home_dir, random_string);
+    let temp_dir = std::path::Path::new(&temp_dir);
+    std::fs::create_dir_all(&temp_dir).unwrap();
+    temp_dir.to_path_buf()
 }

--- a/judge-server/src/main.rs
+++ b/judge-server/src/main.rs
@@ -18,14 +18,16 @@ async fn ping() -> impl Responder {
 
 #[post("/submit")]
 async fn submit_code(submission: web::Json<CodeSubmission>) -> impl Responder {
+    let home_dir = std::env::var("HOME").expect("cannot find home directory");
     let random_string: String = Uuid::new_v4().to_string();
-    let temp_dir = format!("./.temp/{}", random_string);
+    let temp_dir = format!("{}/.waffle-judge/temp/{}", home_dir, random_string);
     let temp_dir = std::path::Path::new(&temp_dir);
-    std::fs::create_dir_all(temp_dir).unwrap();
+
+    std::fs::create_dir_all(&temp_dir).unwrap();
 
     let output = match submission.language {
-        Language::C => run_c_code(&submission.code, temp_dir),
-        Language::JAVA => run_java_code(&submission.code, temp_dir),
+        Language::C => run_c_code(&submission.code, &temp_dir),
+        Language::JAVA => run_java_code(&submission.code, &temp_dir),
     };
 
     std::fs::remove_dir_all(temp_dir).unwrap();
@@ -35,7 +37,9 @@ async fn submit_code(submission: web::Json<CodeSubmission>) -> impl Responder {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    std::fs::create_dir_all("./.temp").unwrap();
+    let home_dir = std::env::var("HOME").expect("cannot find home directory");
+    let waffle_judge_dir = format!("{}/.waffle-judge/temp", home_dir);
+    std::fs::create_dir_all(&waffle_judge_dir).unwrap();
     HttpServer::new(|| App::new().service(ping).service(submit_code))
         .bind("0.0.0.0:8080")?
         .run()

--- a/tests/bruno/compile-errors/[C] no semicolon.bru
+++ b/tests/bruno/compile-errors/[C] no semicolon.bru
@@ -1,0 +1,26 @@
+meta {
+  name: [C] no semicolon
+  type: http
+  seq: 2
+}
+
+post {
+  url: http://127.0.0.1:8080/submit
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "language": "C",
+    "code": "#include <stdio.h>\nint main() { printf(\"Hello World\") }"
+  }
+}
+
+assert {
+  res.body.stdout: eq ""
+}

--- a/tests/bruno/hacks/[C] run shell - ls.bru
+++ b/tests/bruno/hacks/[C] run shell - ls.bru
@@ -1,0 +1,30 @@
+meta {
+  name: [C] run shell - ls
+  type: http
+  seq: 2
+}
+
+post {
+  url: http://127.0.0.1:8080/submit
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "language": "C",
+    "code": "#include <stdlib.h>\nint main() { int result = system(\"ls -a\"); printf(\"%d\", result); }"
+  }
+}
+
+tests {
+  test("should return non-zero number", function() {
+    const result = res.body.stdout;
+    const isValid = !isNaN(Number(result)) && Number(result) !== 0;
+    expect(isValid).to.equal(true);
+  });
+}

--- a/tests/bruno/hacks/[C] run shell - rm.bru
+++ b/tests/bruno/hacks/[C] run shell - rm.bru
@@ -1,0 +1,30 @@
+meta {
+  name: [C] run shell - rm
+  type: http
+  seq: 2
+}
+
+post {
+  url: http://127.0.0.1:8080/submit
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "language": "C",
+    "code": "#include <stdlib.h>\n#include <stdio.h>\nint main() { int result = system(\"touch /tmp/isolate_test\"); printf(\"%d\", result); }"
+  }
+}
+
+tests {
+  test("should return non-zero number", function() {
+    const result = res.body.stdout;
+    const isValid = !isNaN(Number(result)) && Number(result) !== 0;
+    expect(isValid).to.equal(true);
+  });
+}


### PR DESCRIPTION
## 날짜
2024-07-30

## 주제
isolate 로 돌린다.

## 맥락
보안을 위해 isolate 가 필요하며 2023년부터 정해져있던 대전제. isolate 말고 다른 대안들도 있었겠지만 찾아볼 필요가 없었다.

## 결정
isolate 를 적용한다. 컴파일 시에는 isolate 를 이용하지 않고, 실행할 때만 isolate 를 활용한다.

## 관련 링크
- https://wafflestudio.slack.com/archives/C07DDPK0TD4/p1722339713312179
- https://wafflestudio.slack.com/archives/C06M9K1LT36/p1721634497084719

## 논의 참여자
@jj1kim @minkyu97 @woohm402

## 기타
- isolate 를 활용하게 되며 절대 경로가 필요해져서 임시폴더를 `./.temp` 에서 `$HOME/.waffle-judge/temp` 로 변경했습니다. 로컬에서 테스트하면 `$HOME/.waffle-judge/temp` 경로가 자동으로 생성되게 됩니다.
- 일단은 C에만 적용했습니다. 나머지도 이어서 붙여보겠습니다.