### PR TITLE
feat: ci 액션에 경로 필터 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,19 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Dockerfile'
+      - 'Cargo.*'
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Dockerfile'
+      - 'Cargo.*'
 
 jobs:
   test:


### PR DESCRIPTION
## 추가된 기능
ci 액션에 경로 필터를 추가

## 테스트 방법
관련 없는 경로의 파일만 수정한 뒤 PR 올려서 ci 액션 안 돌아가는지 보기
일단 이 PR의 액션은 안 돌아가야 합니다.

## 관련 링크
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

