### PR TITLE
🏗️ use self hosted runner for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,25 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
+      - name: Set Image Name
+        id: image-name
+        run: echo "IMAGE_NAME=hodu:ci-$(openssl rand -hex 8)" >> $GITHUB_ENV
       - name: Build & Run Server
         run: |
-          docker build -t hodu .
-          docker run --privileged -dp 8080:8080 hodu
-      - name: Install Test Cli
-        run: |
-          npm install -g @usebruno/cli
+          sudo docker build -t $IMAGE_NAME .
+          sudo docker run --privileged -dp 8081:8080 $IMAGE_NAME
       - name: Run Tests
         working-directory: hodu-server/tests/bruno
         run: |
+          source ~/.bashrc
           bru run --tests-only --env local
+      - name: Cleanup Docker Image
+        if: always()
+        run: |
+          sudo docker stop $(sudo docker ps -q --filter ancestor=$IMAGE_NAME)
+          sudo docker rm $(sudo docker ps -a -q --filter ancestor=$IMAGE_NAME)
+          sudo docker rmi $IMAGE_NAME
+          sudo docker system prune -af

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,4 +25,5 @@
 ## CI/CD
 
 - CI는 Github Actions 를 사용합니다. [여기](./.github/workflows/ci.yml) 을 참고해 주세요.
+  - cgroup v1 만 활성화된 호스트에서 수행해야 하는데, 이제 모두 outdate되어서 GitHub Actions 가 기본으로 제공하지 않기 때문에 CI에는 Self Hosted Runner 를 사용합니다. 이때 hodu-dev 가 배포되어 있는 ec2를 이용합니다.
 - CD는 아직 구축되어 있지 않습니다.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,11 @@ cargo run
 ```
 
 로컬에 isolate 가 설치되어 있다면 아래와 같이 Docker 를 활용할 수밖에 없습니다.
+로컬에서는 8081번 포트를 이용합니다.
 
 ```sh
 docker build -t hodu .
-docker run --privileged -dp 8080:8080 hodu
+docker run --privileged -dp 8081:8080 hodu
 ```
 
 ## Test
@@ -44,6 +45,15 @@ docker run --privileged -dp 8080:8080 hodu
 ```bash
 cd hodu-server/tests/bruno
 bru run --env local
+```
+
+## Deploy
+
+배포할 때는 8080번 포트를 이용합니다.
+
+```sh
+docker build -t hodu .
+docker run --privileged -dp 8080:8080 hodu
 ```
 
 <br/><br/>

--- a/hodu-server/tests/bruno/environments/local.bru
+++ b/hodu-server/tests/bruno/environments/local.bru
@@ -1,3 +1,3 @@
 vars {
-  baseURL: http://127.0.0.1:8080
+  baseURL: http://127.0.0.1:8081
 }


### PR DESCRIPTION
## 날짜
- 2024.08.09

## 주제
- CI를 self-hosted runner에서 돌린다

## 맥락
- GitHub Actions 에서 기본 제공하는 Linux 버전들은 모두 cgroup 2를 기본으로 하고 있어서 호두를 돌릴 수 없다

## 결정
- 따라서 cgroup 1 으로 세팅되어 있는 hodu dev 를 이용한다

## 관련 링크
- https://wafflestudio.slack.com/archives/C07DDPK0TD4/p1723136745919759

## 논의 참여자
@minkyu97 @woohm402
