### PR TITLE
feat: 동시 채점 수 제한

### DIFF
--- a/hodu-server/src/api/judge/view.rs
+++ b/hodu-server/src/api/judge/view.rs
@@ -1,18 +1,24 @@
-use std::panic::AssertUnwindSafe;
+use std::{panic::AssertUnwindSafe, sync::atomic::Ordering, time::Duration};
 
 use actix_web::{post, web, Responder};
 use hodu_core::{mark, MarkParams};
 
 use futures::FutureExt;
 
-use crate::api::judge::{
-    error::JudgeError,
-    schema::{CodeSubmission, MarkResponse},
+use crate::{
+    api::judge::{
+        error::JudgeError,
+        schema::{CodeSubmission, MarkResponse},
+    },
+    MarkCounter,
 };
+
+const MAX_SUBMISSIONS: u32 = 20;
 
 #[post("/submit")]
 async fn submit_code(
     submission: Result<web::Json<CodeSubmission>, actix_web::Error>,
+    counter: web::Data<MarkCounter>,
 ) -> Result<impl Responder, JudgeError> {
     let submission = submission.map_err(|e| JudgeError::PayloadParseError(e))?;
     tracing::info!(
@@ -21,6 +27,14 @@ async fn submit_code(
         submission.language
     );
 
+    let mut current_count = counter.count.load(Ordering::SeqCst);
+    while current_count >= MAX_SUBMISSIONS {
+        tracing::info!("Max submissions reached, waiting for a slot...");
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        current_count = counter.count.load(Ordering::SeqCst);
+    }
+    let previous_count = counter.count.fetch_add(1, Ordering::SeqCst);
+    tracing::info!("Current count: {}", previous_count + 1);
     let output = AssertUnwindSafe(mark(MarkParams {
         language: &submission.language.clone().into(),
         code: &submission.code,
@@ -31,7 +45,11 @@ async fn submit_code(
     }))
     .catch_unwind()
     .await
-    .map_err(|_| JudgeError::HoduCoreError)?;
+    .map_err(|_| {
+        counter.count.fetch_sub(1, Ordering::SeqCst);
+        JudgeError::HoduCoreError
+    })?;
+    counter.count.fetch_sub(1, Ordering::SeqCst);
 
     Ok(web::Json(
         serde_json::to_value(MarkResponse::new(&output, &submission.fields)).unwrap(),

--- a/hodu-server/src/main.rs
+++ b/hodu-server/src/main.rs
@@ -1,13 +1,27 @@
-use actix_web::{App, HttpServer};
+use std::sync::atomic::AtomicU32;
+
+use actix_web::{web, App, HttpServer};
 
 mod api;
+
+pub struct MarkCounter {
+    count: AtomicU32,
+}
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     tracing_subscriber::fmt::init();
 
-    HttpServer::new(|| App::new().service(api::v1_router()))
-        .bind("0.0.0.0:8080")?
-        .run()
-        .await
+    let counter = web::Data::new(MarkCounter {
+        count: AtomicU32::new(0),
+    });
+
+    HttpServer::new(move || {
+        App::new()
+            .app_data(counter.clone())
+            .service(api::v1_router())
+    })
+    .bind("0.0.0.0:8080")?
+    .run()
+    .await
 }


### PR DESCRIPTION
## 추가된 기능
메모리가 터지는 것을 방지하기 위해 동시 채점 수를 제한합니다.

## 테스트 방법
동시에 여러 요청을 날리며 log를 찍어봅니다.
테스트를 위해 python의 aiohttp 라이브러리르 이용하여 동시에 요청하는 상황을 시뮬레이션해보았습니다.

## 관련 링크
https://wafflestudio.slack.com/archives/C07DDPK0TD4/p1723207545909049