### PR TITLE
🩹 SG 는 RuntimeError 로 판정한다

### DIFF
--- a/hodu-core/src/sandbox/isolate.rs
+++ b/hodu-core/src/sandbox/isolate.rs
@@ -94,11 +94,11 @@ impl Sandbox for Isolate {
 
                 let status = if meta_cg_oom_killed == 1 {
                     SandboxResultStatus::MemoryLimitExceeded
-                } else if meta_status == "RE" {
+                } else if meta_status == "RE" || meta_status == "SG" {
                     SandboxResultStatus::RuntimeError
                 } else if meta_status == "TO" {
                     SandboxResultStatus::TimeLimitExceeded
-                } else if meta_status == "SG" || meta_status == "XX" {
+                } else if meta_status == "XX" {
                     is_internal_error = true;
                     SandboxResultStatus::RuntimeError
                 } else if !result.status.success() {


### PR DESCRIPTION
## 버그 설명
- SG가 InternalError로 내려가고 있어서 SegFault 상황에서 InternalError가 떨어지고 있었다

## 해결책
- SG를 RuntimeError로 판단하도록 변경한다

## 관련 링크

- https://wafflestudio.slack.com/archives/C07DDPK0TD4/p1723428998079919?thread_ts=1723427262.058969&cid=C07DDPK0TD4


