### PR TITLE
🧑‍💻 빌드캐시만 날리는 걸로 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         run: |
           sudo docker build -t $IMAGE_NAME .
           sudo docker run --privileged -dp 8081:8080 $IMAGE_NAME
-          sudo docker system prune -af
       - name: Run Tests
         working-directory: hodu-server/tests/bruno
         run: |
@@ -33,3 +32,4 @@ jobs:
           sudo docker stop $(sudo docker ps -q --filter ancestor=$IMAGE_NAME)
           sudo docker rm $(sudo docker ps -a -q --filter ancestor=$IMAGE_NAME)
           sudo docker rmi $IMAGE_NAME
+          sudo docker buildx prune -af


### PR DESCRIPTION
## 기존 코드의 문제점
- ci때마다 docker system prune 을 하다 보니 써야 되는 이미지도 날라갔습니다.

## 리팩토링 방법
- 이미지는 안 날아가도록 빌드캐시만 날립니다.

## 관련 링크
- https://wafflestudio.slack.com/archives/C07DDPK0TD4/p1723225631557579
